### PR TITLE
use oai-pmh resumptionToken for pagination

### DIFF
--- a/configs/config_fuberlin.ini
+++ b/configs/config_fuberlin.ini
@@ -9,7 +9,7 @@ repository_name=FU Berlin Refubium
 repository_URI=https://refubium.fu-berlin.de/
 [CRAWLER]
 # Repository API URL
-api_url=https://refubium.fu-berlin.de/oai/dnb?verb=ListRecords&resumptionToken=xMetaDissPlus////
+api_url=https://refubium.fu-berlin.de/oai/dnb?verb=ListRecords&metadataPrefix=xMetaDissPlus
 # partitions: 100 records for each request.
 offset_count=100
 #start number for paging. Since we do not want to retrieve all the data always.

--- a/configs/config_huberlin.ini
+++ b/configs/config_huberlin.ini
@@ -8,7 +8,7 @@ repository_name=HU Berlin edoc
 repository_URI=https://edoc.hu-berlin.de/
 [CRAWLER]
 # Repository API URL
-api_url=https://edoc.hu-berlin.de/oai/request/?verb=ListRecords&resumptionToken=oai_dc////
+api_url=https://edoc.hu-berlin.de/oai/request/?verb=ListRecords&metadataPrefix=oai_dc
 offset_count=100
 #start number for paging. Since we do not want to retrieve all the data always.
 start_number=26399

--- a/configs/config_tuberlin.ini
+++ b/configs/config_tuberlin.ini
@@ -9,7 +9,7 @@ repository_name=TU Berlin Depositonce
 repository_URI=https://depositonce.tu-berlin.de/
 [CRAWLER]
 # Repository API URL
-api_url=https://api-depositonce.tu-berlin.de/server/oai/request?verb=ListRecords&resumptionToken=oai_dc////
+api_url=https://api-depositonce.tu-berlin.de/server/oai/request?verb=ListRecords&metadataPrefix=oai_dc
 offset_count=100
 #start number for paging. Since we do not want to retrieve all the data always.
 start_number=16076


### PR DESCRIPTION
this fixes https://github.com/sefeoglu/dcat-converter/issues/13

Changes:
- on first request to api get the resumptionToken
- use the resumptionToken from the previous request for the next request until no resuptionToken is delivered
- configs: use metadataPrefix parameter for first request.